### PR TITLE
Rename 'clear' function as it interferes with the default clear command

### DIFF
--- a/bishop.sh
+++ b/bishop.sh
@@ -26,7 +26,7 @@ function red() {
     echo -ne "${red}"
 }
 
-function clear() {
+function no_colour() {
     echo -ne "${no_colour}"
 }
 
@@ -34,7 +34,7 @@ function _bishop() {
     if [ $1 == "upgrade" ]; then
         blue
         echo "Upgrading bishop..."
-        clear
+        no_colour
         currentDir=$(pwd)
         cd `_currentRunningDirectory`
         curl -H 'Cache-Control: no-cache' -# https://raw.githubusercontent.com/stuartervine/bishop/master/bishop.sh > bishop.sh


### PR DESCRIPTION
Naming this function `clear` interferes with the default `clear` command in all the terminals I've used and I like to clear things up sometimes. 

Incidentally, I started trying to port bishop to zsh as that's what I use on my Mac, but I gave up after sinking a few hours into it. If you'd be up for giving me a helping hand I'm up for finishing that work. It's a useful tool!